### PR TITLE
Correct docs on subsampling mode auto

### DIFF
--- a/src/NetVips/Enums.cs
+++ b/src/NetVips/Enums.cs
@@ -569,7 +569,7 @@ public static class Enums
     /// </summary>
     public enum ForeignSubsample
     {
-        /// <summary>Prevent subsampling when quality > 90.</summary>
+        /// <summary>Prevent subsampling when quality >= 90.</summary>
         Auto = 0, // "auto"
 
         /// <summary>Always perform subsampling.</summary>


### PR DESCRIPTION
[subsampling is prevented when quality >= 90, not > 90](https://github.com/libvips/libvips/blob/655618737fc56bc691b1f8aae5bf19b2356a751d/libvips/include/vips/foreign.h#L491)